### PR TITLE
Update: add additional label styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ While looking around for a good option, I had trouble finding a timezone select 
 
 #### Demo: [ndom91.github.io/react-timezone-select](https://ndom91.github.io/react-timezone-select/)
 
+This demo is also available in the `./examples` directory. Simply run `npm start` after installing everything and webpack dev server should begin, where you will be able to find the demo locally at `localhost:3001`.
+
 ## 🏗️ Installing
 
 ```bash
@@ -70,10 +72,10 @@ ReactDOM.render(<App />, rootElement)
 - `value` - `{ value: string, label: string }`
 - `onBlur` - `() => void`
 - `onChange` - `(timezone) => void`
-- `labelStyle` - `'original'|'altName'|'abbrev'`
+- `labelStyle` - `'original' | 'altName' | 'abbrev'`
 - Any other props get passed along to `react-select`
 
-**New in 0.9.0** We've added multiple label styles, based upon a generous pull request and the [`spacetime-informal`](https://npm.im/spacetime-informal) library.
+> **New in 0.9.0** We've added multiple label styles, based upon a generous pull request and the [`spacetime-informal`](https://npm.im/spacetime-informal) library.
 
 #### `original`
 
@@ -89,22 +91,12 @@ ReactDOM.render(<App />, rootElement)
 
 The demo page will show you all three types of values available for each selected timezone.
 
-## 🖥️ Example
-
-#### Demo: [ndom91.github.io/react-timezone-select/](https://ndom91.github.io/react-timezone-select/)
-
-Theres a small example page / implementation available in the `./examples` directory, simply run `npm start` after installing everything and webpack dev server should begin, where you will be able to find the demo at `localhost:3001`
-
-> ![Screenshot 1](https://imgur.com/6lnxeEV.png)
-
-> ![Screenshot 3](https://imgur.com/HF6E9hH.png)
-
 ## 🚧 Contributing
 
 Pull requests are always welcome!
 
 ## 🙏 Thanks
 
-- [Carlos Matallin](https://github.com/matallo/) + [Demo](https://codepen.io/matallo/pen/WEjKqG?editors=1010)
+- [Carlos Matallin](https://github.com/matallo/)
 - [spacetime](https://github.com/spencermountain/spacetime)
 - [react-select](https://react-select.com)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,24 @@ ReactDOM.render(<App />, rootElement)
 - `value` - `{ value: string, label: string }`
 - `onBlur` - `() => void`
 - `onChange` - `(timezone) => void`
-- any other `react-select` props, className, etc. - we pass it all on down now.
+- `labelStyle` - `'original'|'altName'|'abbrev'`
+- Any other props get passed along to `react-select`
+
+**New in 0.9.0** We've added multiple label styles, based upon a generous pull request and the [`spacetime-informal`](https://npm.im/spacetime-informal) library.
+
+#### `original`
+
+![original labelstyle](https://user-images.githubusercontent.com/7415984/95472863-cecf7400-0983-11eb-8b2b-5cdb04e57881.png)
+
+#### `altName`
+
+![altName labelstyle](https://user-images.githubusercontent.com/7415984/95472987-ed356f80-0983-11eb-8bb5-5cf389f2244a.png)
+
+#### `abbrev`
+
+![abbrev labelstyle](https://user-images.githubusercontent.com/7415984/95472714-a9426a80-0983-11eb-9a5f-301a51c92d8a.png)
+
+The demo page will show you all three types of values available for each selected timezone.
 
 ## 🖥️ Example
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ ReactDOM.render(<App />, rootElement)
 - `labelStyle` - `'original' | 'altName' | 'abbrev'`
 - Any other props get passed along to `react-select`
 
-> **New in 0.9.0** We've added multiple label styles, based upon a generous pull request and the [`spacetime-informal`](https://npm.im/spacetime-informal) library.
+> **New in 0.9.0** - We've added multiple label styles, based upon a generous pull request and the [`spacetime-informal`](https://npm.im/spacetime-informal) library.
 
 #### `original`
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ const App = () => {
           label: '{selectedTimezone.label}'
         </span>
         <br />
+        <span style={{ marginLeft: '20px', fontWeight: '500' }}>
+          label: '{selectedTimezone.altName}'
+        </span>
+        <br />
+        <span style={{ marginLeft: '20px', fontWeight: '500' }}>
+          label: '{selectedTimezone.abbrev}'
+        </span>
+        <br />
         {'}'}
       </div>
     </div>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -13,17 +13,31 @@ const App = () => {
 
   return (
     <div className='App'>
-      <h2>react-timezone-select</h2>
-      <blockquote>Please make a selection</blockquote>
+      <div className='header'>
+        <h2>react-timezone-select</h2>
+        <p>
+          <a
+            href='https://ndo.dev'
+            alt='ndom91 homepage'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='author'
+          >
+            ndom91
+          </a>
+        </p>
+      </div>
       <div
         style={{
           display: 'flex',
-          width: '80%',
+          width: 'min(100%, 400px)',
           justifyContent: 'space-around',
+          marginTop: '50px',
         }}
         onChange={handleLabelChange}
         checked={labelStyle}
       >
+        <span>Label Style:</span>
         <label for='original'>
           <input
             type='radio'
@@ -66,7 +80,7 @@ const App = () => {
           onBlur={() => console.log('Blur!')}
         />
       </div>
-      <h3>Output:</h3>
+      <h3>Return Value:</h3>
       <div className='code'>
         <span style={{ fontWeight: '500' }}>{'{'}</span> <br />
         <span style={{ marginLeft: '20px', fontWeight: '500' }}>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -5,15 +5,62 @@ import './styles.css'
 
 const App = () => {
   const [selectedTimezone, setSelectedTimezone] = useState({})
+  const [labelStyle, setLabelStyle] = useState('original')
+
+  const handleLabelChange = event => {
+    setLabelStyle(event.target.value)
+  }
 
   return (
     <div className='App'>
       <h2>react-timezone-select</h2>
       <blockquote>Please make a selection</blockquote>
+      <div
+        style={{
+          display: 'flex',
+          width: '80%',
+          justifyContent: 'space-around',
+        }}
+        onChange={handleLabelChange}
+        checked={labelStyle}
+      >
+        <label for='original'>
+          <input
+            type='radio'
+            id='original'
+            name='labelStyle'
+            value='original'
+            checked={labelStyle === 'original'}
+          />
+          original
+        </label>
+        <label for='altName'>
+          <input
+            type='radio'
+            id='altName'
+            name='labelStyle'
+            value='altName'
+            checked={labelStyle === 'altName'}
+          />
+          altName
+        </label>
+        <label for='abbrev'>
+          <input
+            type='radio'
+            id='abbrev'
+            name='labelStyle'
+            value='abbrev'
+            checked={labelStyle === 'abbrev'}
+          />
+          abbrev
+        </label>
+      </div>
       <div className='select-wrapper'>
         <TimezoneSelect
           value={selectedTimezone}
           onChange={tz => setSelectedTimezone(tz)}
+          labelStyle={labelStyle}
+          // onBlur={() => console.log('Blur!')}
         />
       </div>
       <h3>Output:</h3>
@@ -27,10 +74,22 @@ const App = () => {
           label: '{selectedTimezone.label}'
         </span>
         <br />
-        <span style={{ marginLeft: '20px', fontWeight: '500' }}>
-          abbrev: '{selectedTimezone.abbrev}'
-        </span>
-        <br />
+        {selectedTimezone.altName && (
+          <>
+            <span style={{ marginLeft: '20px', fontWeight: '500' }}>
+              name: '{selectedTimezone.altName}'
+            </span>
+            <br />
+          </>
+        )}
+        {selectedTimezone.abbrev && (
+          <>
+            <span style={{ marginLeft: '20px', fontWeight: '500' }}>
+              abbrev: '{selectedTimezone.abbrev}'
+            </span>
+            <br />
+          </>
+        )}
         {'}'}
       </div>
     </div>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -58,9 +58,12 @@ const App = () => {
       <div className='select-wrapper'>
         <TimezoneSelect
           value={selectedTimezone}
-          onChange={tz => setSelectedTimezone(tz)}
+          onChange={tz => {
+            console.log(tz)
+            setSelectedTimezone(tz)
+          }}
           labelStyle={labelStyle}
-          // onBlur={() => console.log('Blur!')}
+          onBlur={() => console.log('Blur!')}
         />
       </div>
       <h3>Output:</h3>

--- a/examples/src/styles.css
+++ b/examples/src/styles.css
@@ -8,8 +8,22 @@
   flex-direction: column;
 }
 
+.header * {
+  margin: 0px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.author {
+  text-decoration: none;
+  font-size: 0.8rem;
+  padding-top: 10px;
+  color: #666;
+}
+
 .select-wrapper {
-  margin-top: 50px;
+  margin-top: 15px;
   width: 500px;
   max-width: 90vw;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timezone-select",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Usable, dynamic React Timezone Select",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timezone-select",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Usable, dynamic React Timezone Select",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,25 +7,22 @@ const i18n = {
   'Pacific/Midway': 'Midway Island, Samoa',
   'Pacific/Honolulu': 'Hawaii',
   'America/Juneau': 'Alaska',
-  'America/Dawson': 'Pacific Time (US and Canada); Tijuana',
-  'America/Boise': 'Mountain Time (US and Canada)',
+  'America/Dawson': 'Tijuana, Pacific Time',
+  'America/Boise': 'Mountain Time',
   'America/Chihuahua': 'Chihuahua, La Paz, Mazatlan',
   'America/Phoenix': 'Arizona',
-  'America/Chicago': 'Central Time (US and Canada)',
+  'America/Chicago': 'Central Time',
   'America/Regina': 'Saskatchewan',
   'America/Mexico_City': 'Guadalajara, Mexico City, Monterrey',
   'America/Belize': 'Central America',
-  'America/Detroit': 'Eastern Time (US and Canada)',
-  'America/Indiana/Indianapolis': 'Indiana (East)',
+  'America/Detroit': 'Eastern Time',
   'America/Bogota': 'Bogota, Lima, Quito',
-  'America/Glace_Bay': 'Atlantic Time (Canada)',
   'America/Caracas': 'Caracas, La Paz',
   'America/Santiago': 'Santiago',
   'America/St_Johns': 'Newfoundland and Labrador',
   'America/Sao_Paulo': 'Brasilia',
   'America/Argentina/Buenos_Aires': 'Buenos Aires, Georgetown',
   'America/Godthab': 'Greenland',
-  'Etc/GMT+2': 'Mid-Atlantic',
   'Atlantic/Azores': 'Azores',
   'Atlantic/Cape_Verde': 'Cape Verde Islands',
   GMT: 'Dublin, Edinburgh, Lisbon, London',
@@ -81,42 +78,6 @@ const i18n = {
   'Pacific/Tongatapu': "Nuku'alofa",
 }
 
-const options = []
-Object.entries(i18n)
-  .reduce((obj, entry) => {
-    const a = spacetime.now().goto(entry[0])
-    const tz = a.timezone()
-    const tzDisplay = display(entry[0])
-    let abbrev = entry[0]
-    let altName = entry[0]
-    if (tzDisplay && tzDisplay.daylight && tzDisplay.standard) {
-      abbrev = a.isDST() ? tzDisplay.daylight.abbrev : tzDisplay.standard.abbrev
-      altName = a.isDST() ? tzDisplay.daylight.name : tzDisplay.standard.name
-    }
-    obj.push({
-      name: entry[0],
-      label: entry[1],
-      offset: tz.current.offset,
-      abbrev: abbrev,
-      altName: altName,
-    })
-    return obj
-  })
-  .sort((a, b) => {
-    return a.offset - b.offset
-  })
-  .map(tz => {
-    if (tz.offset === undefined) return false
-    const min = tz.offset * 60
-    const hr = `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : min % 60)
-    options.push({
-      value: tz.name,
-      label: `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label}`,
-      abbrev: tz.abbrev,
-      altName: tz.altName,
-    })
-  })
-
 const TimezoneSelect = ({
   value,
   onBlur,
@@ -159,21 +120,25 @@ const TimezoneSelect = ({
         if (tz.offset === undefined) return false
         let label = ''
         const min = tz.offset * 60
-        const hr = `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : min % 60)
+        const hr =
+          `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
+        const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label}`
+
         switch (labelStyle) {
           case 'original':
-            label = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label}`
+            label = prefix
             break
           case 'altName':
-            label = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label} 
-            ${!tz.altName.includes('/') ? `(${tz.altName})` : ''}`
+            label = `${prefix} ${
+              !tz.altName.includes('/') ? `(${tz.altName})` : ''
+            }`
             break
           case 'abbrev':
-            label = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label} 
+            label = `${prefix} 
             ${tz.abbrev.length < 5 ? `(${tz.abbrev})` : ''}`
             break
           default:
-            label = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${tz.label}`
+            label = `${prefix}`
         }
         options.push({
           value: tz.name,


### PR DESCRIPTION
Extended @braingu-matt's idea a bit with a new prop `labelStyle` which allows the user to select three different label styles as of now (i'm open to additions / changes!). 

`original` - Which is how it was previously
`altName` - Which includes the spacetime-informal value name if present
`abbrev` - Which includes the spacetime-informal value abbrev if present

And here's a preview of the dropdown values with the various labelStyles selected:

### `original`
![image](https://user-images.githubusercontent.com/7415984/95473442-659c3080-0984-11eb-99ac-614921cee491.png)

### `altName`
![image](https://user-images.githubusercontent.com/7415984/95473464-6a60e480-0984-11eb-850b-ead60fdbf6f6.png)

### `abbrev`
![image](https://user-images.githubusercontent.com/7415984/95473467-6d5bd500-0984-11eb-968e-a5dfac2ba0e0.png)