### PR TITLE
Implemented findFuzzyTz, allowing for (valid) non-dropdown timezones

### DIFF
--- a/src/__tests__/TimezoneSelect.test.tsx
+++ b/src/__tests__/TimezoneSelect.test.tsx
@@ -119,6 +119,21 @@ test('load and passes react-select props', async () => {
   expect(getByText('Please Select a Timezone')).toBeInTheDocument()
 })
 
+test('can determine timezone by approximate match', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value="Europe/Rome"
+      onChange={e => e}
+    />
+  )
+
+  expect(
+    getByText(
+      /\(GMT\+[1-2]:00\) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna$/
+    )
+  ).toBeInTheDocument()
+})
+
 test('select drop-downs must use the fireEvent.change', () => {
   const onChangeSpy = jest.fn()
   const { container } = render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -172,10 +172,42 @@ const TimezoneSelect = ({
     onChange && onChange(tz)
   }
 
+  const findFuzzyTz = (zone: string): ITimezoneOption => {
+    let currentTime;
+    try {
+      currentTime = spacetime.now(zone);
+    }
+    catch (err) {
+      return;
+    }
+    return getOptions.filter( (tz: ITimezoneOption) => (tz.offset === currentTime.timezone().current.offset))
+      .map( (tz: ITimezoneOption) => {
+        let score = 0;
+        if (currentTime.timezones[ tz.value.toLowerCase() ] && !!currentTime.timezones[ tz.value.toLowerCase() ].dst === currentTime.timezone().hasDst) {
+
+          if (tz.value.toLowerCase().indexOf(currentTime.tz.substr(currentTime.tz.indexOf('/') + 1)) !== -1) {
+            score += 8;
+          }
+          if (tz.label.toLowerCase().indexOf(currentTime.tz.substr(currentTime.tz.indexOf('/') + 1)) !== -1) {
+            score += 4;
+          }
+          if (tz.value.toLowerCase().indexOf(currentTime.tz.substr(0, currentTime.tz.indexOf('/')))) {
+            score += 2;
+          }
+          score += 1;
+        } else if (tz.value === 'GMT') {
+          score += 1;
+        }
+        return { tz, score };
+      })
+      .sort( (a, b) => b.score - a.score )
+      .map( ({ tz, score }) => tz )[0];
+  };
+
   const parseTimezone = (zone: ITimezone) => {
     if (typeof zone === 'object' && zone.value && zone.label) return zone
     if (typeof zone === 'string') {
-      return getOptions.find(tz => tz.value === zone)
+      return getOptions.find(tz => tz.value === zone) || ( zone.indexOf('/') !== -1 && findFuzzyTz(zone) )
     } else if (zone.value && !zone.label) {
       return getOptions.find(tz => tz.value === zone.value)
     }


### PR DESCRIPTION
I've drafted a proposal to implement #25 - I think this is a great feature to add but admittedly it is quite logic heavy - I hope this conveys the intention of the feature request. I've played around with auto-detection of user timeZones using Intl, and I don't think the detection logic itself belongs in this library; but Intl in combination with this PR seems to behave quite well.