### PR TITLE
feat: select pointer

### DIFF
--- a/example/src/Timezone.tsx
+++ b/example/src/Timezone.tsx
@@ -7,9 +7,8 @@ import TimezoneSelect, {
 } from '../../src';
 
 const Timezone = () => {
-  const [selectedTimezone, setSelectedTimezone] = React.useState<ITimezone>(
-    'Europe/Rome',
-  );
+  const [selectedTimezone, setSelectedTimezone] =
+    React.useState<ITimezone>('Europe/Rome');
   const [labelStyle, setLabelStyle] = React.useState<ILabelStyle>('original');
 
   const handleLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,9 +7,10 @@ const config = {
   // using ts-jest
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
+    '.(css|scss)$': '<rootDir>/src/__mocks__/cssStub.ts',
   },
 
-	testEnvironment: "jsdom",
+  testEnvironment: 'jsdom',
 
   // Runs special logic, such as cleaning up components
   // when using React Testing Library and adds special

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timezone-select",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Usable, dynamic React Timezone Select",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -62,10 +62,8 @@
     "typescript": "^4.3.2"
   },
   "prettier": {
-    "singleQuote": true,
     "trailingComma": "es5",
     "semi": false,
-    "jsxSingleQuote": true,
     "arrowParens": "avoid"
   }
 }

--- a/src/__mocks__/cssStub.ts
+++ b/src/__mocks__/cssStub.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  process() {
+    return "module.exports = {};"
+  },
+}

--- a/src/__tests__/TimezoneSelect.test.tsx
+++ b/src/__tests__/TimezoneSelect.test.tsx
@@ -1,21 +1,21 @@
-import React from 'react'
-import { render, findAllByText, fireEvent } from '@testing-library/react'
+import React from "react"
+import { render, findAllByText, fireEvent } from "@testing-library/react"
 
-import TimezoneSelect, { i18nTimezones } from '../index'
+import TimezoneSelect, { i18nTimezones } from "../index"
 
 // react-select react-testing-library jest example tests:
 // https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/__tests__/Select.test.js
 
-test('snapshot - defaults', () => {
+test("snapshot - defaults", () => {
   const { container } = render(
-    <TimezoneSelect value={'Europe/Amsterdam'} onChange={e => e} />
+    <TimezoneSelect value={"Europe/Amsterdam"} onChange={e => e} />
   )
   expect(container).toMatchSnapshot()
 })
 
-test('loads and displays default timezone - passing string', async () => {
+test("loads and displays default timezone - passing string", async () => {
   const { getByText } = render(
-    <TimezoneSelect value={'Europe/Amsterdam'} onChange={e => e} />
+    <TimezoneSelect value={"Europe/Amsterdam"} onChange={e => e} />
   )
 
   expect(
@@ -25,12 +25,12 @@ test('loads and displays default timezone - passing string', async () => {
   ).toBeInTheDocument()
 })
 
-test('loads and displays default timezone - passing full object', async () => {
+test("loads and displays default timezone - passing full object", async () => {
   const { getByText } = render(
     <TimezoneSelect
       value={{
-        value: 'Europe/Amsterdam',
-        label: '(GMT+1:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna',
+        value: "Europe/Amsterdam",
+        label: "(GMT+1:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
       }}
       onChange={e => e}
     />
@@ -43,11 +43,11 @@ test('loads and displays default timezone - passing full object', async () => {
   ).toBeInTheDocument()
 })
 
-test('load and displays labelStyle - altName', async () => {
+test("load and displays labelStyle - altName", async () => {
   const { getByText } = render(
     <TimezoneSelect
-      value={'America/Juneau'}
-      labelStyle='altName'
+      value={"America/Juneau"}
+      labelStyle="altName"
       onChange={e => e}
     />
   )
@@ -57,11 +57,11 @@ test('load and displays labelStyle - altName', async () => {
   ).toBeInTheDocument()
 })
 
-test('load and displays labelStyle - abbrev', async () => {
+test("load and displays labelStyle - abbrev", async () => {
   const { getByText } = render(
     <TimezoneSelect
-      value={'America/Juneau'}
-      labelStyle='abbrev'
+      value={"America/Juneau"}
+      labelStyle="abbrev"
       onChange={e => e}
     />
   )
@@ -69,13 +69,13 @@ test('load and displays labelStyle - abbrev', async () => {
   expect(getByText(/\(GMT-[8-9]:00\) Alaska \(AH[D|S]T\)$/)).toBeInTheDocument()
 })
 
-test('load and displays custom timezone', async () => {
+test("load and displays custom timezone", async () => {
   const { getByText } = render(
     <TimezoneSelect
-      value={'America/Lima'}
+      value={"America/Lima"}
       timezones={{
         ...i18nTimezones,
-        'America/Lima': 'Pittsburgh',
+        "America/Lima": "Pittsburgh",
       }}
       onChange={e => e}
     />
@@ -84,13 +84,13 @@ test('load and displays custom timezone', async () => {
   expect(getByText(/\(GMT-[5-6]:00\) Pittsburgh$/)).toBeInTheDocument()
 })
 
-test('load and displays only 2 custom timezone choices', async () => {
+test("load and displays only 2 custom timezone choices", async () => {
   const { debug, container } = render(
     <TimezoneSelect
-      value={''}
+      value={""}
       timezones={{
-        'America/Lima': 'Pittsburgh',
-        'Europe/Berlin': 'Frankfurt',
+        "America/Lima": "Pittsburgh",
+        "Europe/Berlin": "Frankfurt",
       }}
       menuIsOpen={true}
       onChange={e => e}
@@ -99,32 +99,29 @@ test('load and displays only 2 custom timezone choices', async () => {
   debug()
 
   const items = await findAllByText(container, /^\(GMT[+-][0-9]{1,2}:[0-9]{2}/)
-  console.log(items)
+  // console.log(items)
   expect(items).toHaveLength(2)
 })
 
-test('load and passes react-select props', async () => {
+test("load and passes react-select props", async () => {
   const { getByText } = render(
     <TimezoneSelect
-      value={''}
+      value={""}
       timezones={{
         ...i18nTimezones,
-        'America/Lima': 'Pittsburgh',
+        "America/Lima": "Pittsburgh",
       }}
-      placeholder={'Please Select a Timezone'}
+      placeholder={"Please Select a Timezone"}
       onChange={e => e}
     />
   )
 
-  expect(getByText('Please Select a Timezone')).toBeInTheDocument()
+  expect(getByText("Please Select a Timezone")).toBeInTheDocument()
 })
 
-test('can determine timezone by approximate match', async () => {
+test("can determine timezone by approximate match", async () => {
   const { getByText } = render(
-    <TimezoneSelect
-      value="Europe/Rome"
-      onChange={e => e}
-    />
+    <TimezoneSelect value="Europe/Rome" onChange={e => e} />
   )
 
   expect(
@@ -134,11 +131,11 @@ test('can determine timezone by approximate match', async () => {
   ).toBeInTheDocument()
 })
 
-test('select drop-downs must use the fireEvent.change', () => {
+test("select drop-downs must use the fireEvent.change", () => {
   const onChangeSpy = jest.fn()
   const { container } = render(
     <TimezoneSelect
-      value={'Europe/Amsterdam'}
+      value={"Europe/Amsterdam"}
       onChange={onChangeSpy}
       menuIsOpen={true}
     />
@@ -146,16 +143,16 @@ test('select drop-downs must use the fireEvent.change', () => {
 
   let selectOption = [
     ...container.querySelectorAll('div[id^="react-select"]'),
-  ].find(n => n.textContent === '(GMT-10:00) Hawaii')
+  ].find(n => n.textContent === "(GMT-10:00) Hawaii")
 
   fireEvent.click(selectOption)
 
   expect(onChangeSpy).toHaveBeenCalledTimes(1)
   expect(onChangeSpy).toHaveBeenCalledWith({
-    value: 'Pacific/Honolulu',
-    label: '(GMT-10:00) Hawaii',
-    altName: 'Pacific/Honolulu',
+    value: "Pacific/Honolulu",
+    label: "(GMT-10:00) Hawaii",
+    altName: "Pacific/Honolulu",
     offset: -10,
-    abbrev: 'Pacific/Honolulu',
+    abbrev: "Pacific/Honolulu",
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+.select-wrapper > div > div:hover {
+  cursor: pointer;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,102 +1,102 @@
-import React from 'react'
-import Select from 'react-select'
-import spacetime from 'spacetime'
-import informal from 'spacetime-informal'
-import type { Props as ReactSelectProps } from 'react-select'
-import './index.css'
+import React from "react"
+import Select from "react-select"
+import spacetime from "spacetime"
+import informal from "spacetime-informal"
+import type { Props as ReactSelectProps } from "react-select"
+import "./index.css"
 
-type ExcludeValue<T> = Pick<T, Exclude<keyof T, 'value'>>
+type ExcludeValue<T> = Pick<T, Exclude<keyof T, "value">>
 
 export type ICustomTimezone = {
   [key: string]: string
 }
 
 export const i18nTimezones: ICustomTimezone = {
-  'Pacific/Midway': 'Midway Island, Samoa',
-  'Pacific/Honolulu': 'Hawaii',
-  'America/Juneau': 'Alaska',
-  'America/Boise': 'Mountain Time',
-  'America/Dawson': 'Dawson, Yukon',
-  'America/Chihuahua': 'Chihuahua, La Paz, Mazatlan',
-  'America/Phoenix': 'Arizona',
-  'America/Chicago': 'Central Time',
-  'America/Regina': 'Saskatchewan',
-  'America/Mexico_City': 'Guadalajara, Mexico City, Monterrey',
-  'America/Belize': 'Central America',
-  'America/Detroit': 'Eastern Time',
-  'America/Bogota': 'Bogota, Lima, Quito',
-  'America/Caracas': 'Caracas, La Paz',
-  'America/Santiago': 'Santiago',
-  'America/St_Johns': 'Newfoundland and Labrador',
-  'America/Sao_Paulo': 'Brasilia',
-  'America/Tijuana': 'Tijuana',
-  'America/Argentina/Buenos_Aires': 'Buenos Aires, Georgetown',
-  'America/Godthab': 'Greenland',
-  'America/Los_Angeles': 'Pacific Time',
-  'Atlantic/Azores': 'Azores',
-  'Atlantic/Cape_Verde': 'Cape Verde Islands',
-  GMT: 'UTC',
-  'Europe/London': 'Edinburgh, London',
-  'Europe/Dublin': 'Dublin',
-  'Europe/Lisbon': 'Lisbon',
-  'Africa/Casablanca': 'Casablanca, Monrovia',
-  'Atlantic/Canary': 'Canary Islands',
-  'Europe/Belgrade': 'Belgrade, Bratislava, Budapest, Ljubljana, Prague',
-  'Europe/Sarajevo': 'Sarajevo, Skopje, Warsaw, Zagreb',
-  'Europe/Brussels': 'Brussels, Copenhagen, Madrid, Paris',
-  'Europe/Amsterdam': 'Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna',
-  'Africa/Algiers': 'West Central Africa',
-  'Europe/Bucharest': 'Bucharest',
-  'Africa/Cairo': 'Cairo',
-  'Europe/Helsinki': 'Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius',
-  'Europe/Athens': 'Athens, Istanbul, Minsk',
-  'Asia/Jerusalem': 'Jerusalem',
-  'Africa/Harare': 'Harare, Pretoria',
-  'Europe/Moscow': 'Moscow, St. Petersburg, Volgograd',
-  'Asia/Kuwait': 'Kuwait, Riyadh',
-  'Africa/Nairobi': 'Nairobi',
-  'Asia/Baghdad': 'Baghdad',
-  'Asia/Tehran': 'Tehran',
-  'Asia/Dubai': 'Abu Dhabi, Muscat',
-  'Asia/Baku': 'Baku, Tbilisi, Yerevan',
-  'Asia/Kabul': 'Kabul',
-  'Asia/Yekaterinburg': 'Ekaterinburg',
-  'Asia/Karachi': 'Islamabad, Karachi, Tashkent',
-  'Asia/Kolkata': 'Chennai, Kolkata, Mumbai, New Delhi',
-  'Asia/Kathmandu': 'Kathmandu',
-  'Asia/Dhaka': 'Astana, Dhaka',
-  'Asia/Colombo': 'Sri Jayawardenepura',
-  'Asia/Almaty': 'Almaty, Novosibirsk',
-  'Asia/Rangoon': 'Yangon Rangoon',
-  'Asia/Bangkok': 'Bangkok, Hanoi, Jakarta',
-  'Asia/Krasnoyarsk': 'Krasnoyarsk',
-  'Asia/Shanghai': 'Beijing, Chongqing, Hong Kong SAR, Urumqi',
-  'Asia/Kuala_Lumpur': 'Kuala Lumpur, Singapore',
-  'Asia/Taipei': 'Taipei',
-  'Australia/Perth': 'Perth',
-  'Asia/Irkutsk': 'Irkutsk, Ulaanbaatar',
-  'Asia/Seoul': 'Seoul',
-  'Asia/Tokyo': 'Osaka, Sapporo, Tokyo',
-  'Asia/Yakutsk': 'Yakutsk',
-  'Australia/Darwin': 'Darwin',
-  'Australia/Adelaide': 'Adelaide',
-  'Australia/Sydney': 'Canberra, Melbourne, Sydney',
-  'Australia/Brisbane': 'Brisbane',
-  'Australia/Hobart': 'Hobart',
-  'Asia/Vladivostok': 'Vladivostok',
-  'Pacific/Guam': 'Guam, Port Moresby',
-  'Asia/Magadan': 'Magadan, Solomon Islands, New Caledonia',
-  'Asia/Kamchatka': 'Kamchatka, Marshall Islands',
-  'Pacific/Fiji': 'Fiji Islands',
-  'Pacific/Auckland': 'Auckland, Wellington',
-  'Pacific/Tongatapu': "Nuku'alofa",
+  "Pacific/Midway": "Midway Island, Samoa",
+  "Pacific/Honolulu": "Hawaii",
+  "America/Juneau": "Alaska",
+  "America/Boise": "Mountain Time",
+  "America/Dawson": "Dawson, Yukon",
+  "America/Chihuahua": "Chihuahua, La Paz, Mazatlan",
+  "America/Phoenix": "Arizona",
+  "America/Chicago": "Central Time",
+  "America/Regina": "Saskatchewan",
+  "America/Mexico_City": "Guadalajara, Mexico City, Monterrey",
+  "America/Belize": "Central America",
+  "America/Detroit": "Eastern Time",
+  "America/Bogota": "Bogota, Lima, Quito",
+  "America/Caracas": "Caracas, La Paz",
+  "America/Santiago": "Santiago",
+  "America/St_Johns": "Newfoundland and Labrador",
+  "America/Sao_Paulo": "Brasilia",
+  "America/Tijuana": "Tijuana",
+  "America/Argentina/Buenos_Aires": "Buenos Aires, Georgetown",
+  "America/Godthab": "Greenland",
+  "America/Los_Angeles": "Pacific Time",
+  "Atlantic/Azores": "Azores",
+  "Atlantic/Cape_Verde": "Cape Verde Islands",
+  GMT: "UTC",
+  "Europe/London": "Edinburgh, London",
+  "Europe/Dublin": "Dublin",
+  "Europe/Lisbon": "Lisbon",
+  "Africa/Casablanca": "Casablanca, Monrovia",
+  "Atlantic/Canary": "Canary Islands",
+  "Europe/Belgrade": "Belgrade, Bratislava, Budapest, Ljubljana, Prague",
+  "Europe/Sarajevo": "Sarajevo, Skopje, Warsaw, Zagreb",
+  "Europe/Brussels": "Brussels, Copenhagen, Madrid, Paris",
+  "Europe/Amsterdam": "Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
+  "Africa/Algiers": "West Central Africa",
+  "Europe/Bucharest": "Bucharest",
+  "Africa/Cairo": "Cairo",
+  "Europe/Helsinki": "Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius",
+  "Europe/Athens": "Athens, Istanbul, Minsk",
+  "Asia/Jerusalem": "Jerusalem",
+  "Africa/Harare": "Harare, Pretoria",
+  "Europe/Moscow": "Moscow, St. Petersburg, Volgograd",
+  "Asia/Kuwait": "Kuwait, Riyadh",
+  "Africa/Nairobi": "Nairobi",
+  "Asia/Baghdad": "Baghdad",
+  "Asia/Tehran": "Tehran",
+  "Asia/Dubai": "Abu Dhabi, Muscat",
+  "Asia/Baku": "Baku, Tbilisi, Yerevan",
+  "Asia/Kabul": "Kabul",
+  "Asia/Yekaterinburg": "Ekaterinburg",
+  "Asia/Karachi": "Islamabad, Karachi, Tashkent",
+  "Asia/Kolkata": "Chennai, Kolkata, Mumbai, New Delhi",
+  "Asia/Kathmandu": "Kathmandu",
+  "Asia/Dhaka": "Astana, Dhaka",
+  "Asia/Colombo": "Sri Jayawardenepura",
+  "Asia/Almaty": "Almaty, Novosibirsk",
+  "Asia/Rangoon": "Yangon Rangoon",
+  "Asia/Bangkok": "Bangkok, Hanoi, Jakarta",
+  "Asia/Krasnoyarsk": "Krasnoyarsk",
+  "Asia/Shanghai": "Beijing, Chongqing, Hong Kong SAR, Urumqi",
+  "Asia/Kuala_Lumpur": "Kuala Lumpur, Singapore",
+  "Asia/Taipei": "Taipei",
+  "Australia/Perth": "Perth",
+  "Asia/Irkutsk": "Irkutsk, Ulaanbaatar",
+  "Asia/Seoul": "Seoul",
+  "Asia/Tokyo": "Osaka, Sapporo, Tokyo",
+  "Asia/Yakutsk": "Yakutsk",
+  "Australia/Darwin": "Darwin",
+  "Australia/Adelaide": "Adelaide",
+  "Australia/Sydney": "Canberra, Melbourne, Sydney",
+  "Australia/Brisbane": "Brisbane",
+  "Australia/Hobart": "Hobart",
+  "Asia/Vladivostok": "Vladivostok",
+  "Pacific/Guam": "Guam, Port Moresby",
+  "Asia/Magadan": "Magadan, Solomon Islands, New Caledonia",
+  "Asia/Kamchatka": "Kamchatka, Marshall Islands",
+  "Pacific/Fiji": "Fiji Islands",
+  "Pacific/Auckland": "Auckland, Wellington",
+  "Pacific/Tongatapu": "Nuku'alofa",
 }
 
-export type ILabelStyle = 'original' | 'altName' | 'abbrev'
+export type ILabelStyle = "original" | "altName" | "abbrev"
 export enum LabelType {
-  ORIGINAL = 'original',
-  ALTNAME = 'altName',
-  ABBREV = 'abbrev',
+  ORIGINAL = "original",
+  ALTNAME = "altName",
+  ABBREV = "abbrev",
 }
 
 export type ITimezoneOption = {
@@ -119,7 +119,7 @@ const TimezoneSelect = ({
   value,
   onBlur,
   onChange,
-  labelStyle = 'original',
+  labelStyle = "original",
   timezones = i18nTimezones,
   ...props
 }: Props) => {
@@ -130,7 +130,7 @@ const TimezoneSelect = ({
         const tz = now.timezone()
         const tzStrings = informal.display(zone[0])
 
-        let label = ''
+        let label = ""
         let abbrev = zone[0]
         let altName = zone[0]
 
@@ -145,18 +145,18 @@ const TimezoneSelect = ({
 
         const min = tz.current.offset * 60
         const hr =
-          `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
-        const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
+          `${(min / 60) ^ 0}:` + (min % 60 === 0 ? "00" : Math.abs(min % 60))
+        const prefix = `(GMT${hr.includes("-") ? hr : `+${hr}`}) ${zone[1]}`
 
         switch (labelStyle) {
-          case 'original':
+          case "original":
             label = prefix
             break
-          case 'altName':
-            label = `${prefix} ${!altName.includes('/') ? `(${altName})` : ''}`
+          case "altName":
+            label = `${prefix} ${!altName.includes("/") ? `(${altName})` : ""}`
             break
-          case 'abbrev':
-            label = `${prefix} ${abbrev.length < 5 ? `(${abbrev})` : ''}`
+          case "abbrev":
+            label = `${prefix} ${abbrev.length < 5 ? `(${abbrev})` : ""}`
             break
           default:
             label = `${prefix}`
@@ -202,7 +202,7 @@ const TimezoneSelect = ({
             tz.value
               .toLowerCase()
               .indexOf(
-                currentTime.tz.substr(currentTime.tz.indexOf('/') + 1)
+                currentTime.tz.substr(currentTime.tz.indexOf("/") + 1)
               ) !== -1
           ) {
             score += 8
@@ -211,7 +211,7 @@ const TimezoneSelect = ({
             tz.label
               .toLowerCase()
               .indexOf(
-                currentTime.tz.substr(currentTime.tz.indexOf('/') + 1)
+                currentTime.tz.substr(currentTime.tz.indexOf("/") + 1)
               ) !== -1
           ) {
             score += 4
@@ -219,12 +219,12 @@ const TimezoneSelect = ({
           if (
             tz.value
               .toLowerCase()
-              .indexOf(currentTime.tz.substr(0, currentTime.tz.indexOf('/')))
+              .indexOf(currentTime.tz.substr(0, currentTime.tz.indexOf("/")))
           ) {
             score += 2
           }
           score += 1
-        } else if (tz.value === 'GMT') {
+        } else if (tz.value === "GMT") {
           score += 1
         }
         return { tz, score }
@@ -234,11 +234,11 @@ const TimezoneSelect = ({
   }
 
   const parseTimezone = (zone: ITimezone) => {
-    if (typeof zone === 'object' && zone.value && zone.label) return zone
-    if (typeof zone === 'string') {
+    if (typeof zone === "object" && zone.value && zone.label) return zone
+    if (typeof zone === "string") {
       return (
         getOptions.find(tz => tz.value === zone) ||
-        (zone.indexOf('/') !== -1 && findFuzzyTz(zone))
+        (zone.indexOf("/") !== -1 && findFuzzyTz(zone))
       )
     } else if (zone.value && !zone.label) {
       return getOptions.find(tz => tz.value === zone.value)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import Select from 'react-select'
 import spacetime from 'spacetime'
 import informal from 'spacetime-informal'
 import type { Props as ReactSelectProps } from 'react-select'
+import './index.css'
 
 type ExcludeValue<T> = Pick<T, Exclude<keyof T, 'value'>>
 

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect'
+import "@testing-library/jest-dom/extend-expect"


### PR DESCRIPTION
Added `cursor: pointer` onHover of the select bar.

`react-select` had explicitly decided against it actually, but with the caveat that it was a breaking change and users could easily implement it themselves. (JedWatson/react-select#4069)

Material-UI seems to have `cursor: pointer` on their selects, so I think its the "correct" way to go about it (https://next.material-ui.com/components/selects/).

