### PR TITLE
Add Montevideo to supported timezones

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ export const i18nTimezones: ICustomTimezone = {
   "America/St_Johns": "Newfoundland and Labrador",
   "America/Sao_Paulo": "Brasilia",
   "America/Tijuana": "Tijuana",
+  "America/Montevideo": "Montevideo",
   "America/Argentina/Buenos_Aires": "Buenos Aires, Georgetown",
   "America/Godthab": "Greenland",
   "America/Los_Angeles": "Pacific Time",


### PR DESCRIPTION
## Description ✍️
It currently shows all the capitals of South America in GMT -3:00 except for [Montevideo, Uruguay](https://en.wikipedia.org/wiki/Montevideo)

## What is the new behavior? ✨
- Added `America/Montevideo: Montevideo` to `i18nTimezones` object based on [spacetime](http://spacetime.how/) value

## Demo screenshot
<img width="606" alt="Screen Shot 2021-09-15 at 23 41 47" src="https://user-images.githubusercontent.com/9642510/133541120-03f17d54-9e83-41ec-849c-a9dea4f912e7.png">
