### PR TITLE
WIP: Use specific date to update DST

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/react-timezone-select',
   plugins: [react()],
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ const TimezoneSelect = ({
         const min = tz.current.offset * 60
         const hr =
           `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
-        const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
+        const prefix = `(UTC${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
 
         switch (labelStyle) {
           case 'original':
@@ -74,12 +74,19 @@ const TimezoneSelect = ({
       .sort((a: ITimezoneOption, b: ITimezoneOption) => a.offset - b.offset)
   }, [labelStyle, timezones, date])
 
+  // Re-select time-zone when date changes.
+  React.useEffect(() => {
+    // TODO: This doesn't yet handle the scenario where the time zone is a simple string.
+    const updatedTz = getOptions.find(({ value: v }) => v === value.value)
+    onChange && onChange(updatedTz)
+  }, [date])
+
   const handleChange = (tz: ITimezoneOption) => {
     onChange && onChange(tz)
   }
 
   const findFuzzyTz = (zone: string): ITimezoneOption => {
-    let currentTime = spacetime.now('GMT')
+    let currentTime = spacetime.now('UTC')
     try {
       currentTime = spacetime.now(zone)
     } catch (err) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,23 +19,26 @@ const TimezoneSelect = ({
   onChange,
   labelStyle = 'original',
   timezones,
+  date,
   ...props
 }: Props) => {
   if (!timezones) timezones = allTimezones
   const getOptions = React.useMemo(() => {
     return Object.entries(timezones)
       .reduce<ITimezoneOption[]>((selectOptions, zone) => {
-        const now = spacetime.now(zone[0])
-        const tz = now.timezone()
+        const currentDate = date
+          ? spacetime(date, zone[0])
+          : spacetime.now(zone[0])
+        const tz = currentDate.timezone()
         const tzStrings = soft(zone[0])
 
         let label = ''
-        let abbr = now.isDST()
+        let abbr = currentDate.isDST()
           ? // @ts-expect-error
             tzStrings[0].daylight?.abbr
           : // @ts-expect-error
             tzStrings[0].standard?.abbr
-        let altName = now.isDST()
+        let altName = currentDate.isDST()
           ? tzStrings[0].daylight?.name
           : tzStrings[0].standard?.name
 
@@ -69,7 +72,7 @@ const TimezoneSelect = ({
         return selectOptions
       }, [])
       .sort((a: ITimezoneOption, b: ITimezoneOption) => a.offset - b.offset)
-  }, [labelStyle, timezones])
+  }, [labelStyle, timezones, date])
 
   const handleChange = (tz: ITimezoneOption) => {
     onChange && onChange(tz)

--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -1,10 +1,10 @@
-import type { Props as ReactSelectProps } from "react-select"
+import type { Props as ReactSelectProps } from 'react-select'
 
 export type ICustomTimezone = {
   [key: string]: string
 }
 
-export type ILabelStyle = "original" | "altName" | "abbrev"
+export type ILabelStyle = 'original' | 'altName' | 'abbrev'
 
 export interface ITimezoneOption {
   value: string
@@ -16,9 +16,10 @@ export interface ITimezoneOption {
 
 export type ITimezone = ITimezoneOption | string
 
-export interface Props extends Omit<ReactSelectProps, "onChange"> {
+export interface Props extends Omit<ReactSelectProps, 'onChange'> {
   value: ITimezone
   labelStyle?: ILabelStyle
   onChange?: (timezone: ITimezoneOption) => void
   timezones?: ICustomTimezone
+  date?: Date | string
 }


### PR DESCRIPTION
This change adds an additional optional "date" prop which can be used to set the current date. This can be used to determine whether or not DST should be applied to the listed time zones.

There's still a tiny issue that needs to be hammered out, as mentioned in the in-line comment, and tests are still missing.