### PR TITLE
fix: change Kiev to Kyiv

### DIFF
--- a/src/tests/__snapshots__/TimezoneSelect.spec.tsx.snap
+++ b/src/tests/__snapshots__/TimezoneSelect.spec.tsx.snap
@@ -33,11 +33,9 @@ exports[`snapshot - defaults 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="react-select-2-listbox"
             aria-describedby="react-select-2-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-owns="react-select-2-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"

--- a/src/timezone-list.ts
+++ b/src/timezone-list.ts
@@ -38,7 +38,7 @@ const allTimezones: ICustomTimezone = {
   "Africa/Algiers": "West Central Africa",
   "Europe/Bucharest": "Bucharest",
   "Africa/Cairo": "Cairo",
-  "Europe/Helsinki": "Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius",
+  "Europe/Helsinki": "Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius",
   "Europe/Athens": "Athens, Minsk",
   "Asia/Jerusalem": "Jerusalem",
   "Africa/Harare": "Harare, Pretoria",


### PR DESCRIPTION
✅ “Kyiv” is an official Latin transliteration of the city’s name in the Ukrainian language. This is not the only language spoken in the country - but it is the only official one. 
❌ “Kiev” comes from the Russian way of pronouncing Ukraine’s capital name. For many Ukrainians today it is now associated with so-called “Russification” - banning the use of Ukrainian language in print and other actions by Russian Empire and then Soviet State to strengthen Russian linguistic and political positions in Ukraine.