### PR TITLE
Sync prop changes with ts declaration file

### DIFF
--- a/src/types/timezone.d.ts
+++ b/src/types/timezone.d.ts
@@ -11,7 +11,8 @@ export interface ITimezoneOption {
   altName?: string
 }
 export declare type ITimezone = ITimezoneOption | string
-export interface Props extends Omit<ReactSelectProps, 'onChange'> {
+export interface Props
+  extends Omit<ReactSelectProps<ITimezone, false>, 'onChange'> {
   value: ITimezone
   labelStyle?: ILabelStyle
   onChange?: (timezone: ITimezoneOption) => void


### PR DESCRIPTION

### Description

The changes merged in #89 were not reflected in the final build because of the `.d.ts` still had the old version without the strictly typed ReactSelectProps.

I've tested and built this locally and the changes are reflected into the build with the PR change.

### Linked Issues
