### PR TITLE
fix: Gracefull Handling For Missing Timezones in timezone-soft library

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 'latest'
+          run_install: |
+            - args: [--no-frozen-lockfile]
       - name: Test using Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Test using Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
       - run: pnpm install
       - run: pnpm test:ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test using Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
+        with:
+          version: 'latest'
       - name: Test using Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '14'
-      - run: npm install
-      - run: npm run test:ci
+      - run: pnpm install
+      - run: pnpm test:ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
       - name: Test using Node.js
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "react-select": "^5.7.0",
-    "spacetime": "^7.1.4",
-    "timezone-soft": "^1.3.1"
+    "spacetime": "^7.4.1",
+    "timezone-soft": "^1.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,16 +21,16 @@ specifiers:
   react-dom: ^17
   react-select: ^5.7.0
   simple-git-hooks: ^2.7.0
-  spacetime: ^7.1.4
-  timezone-soft: ^1.3.1
+  spacetime: ^7.4.1
+  timezone-soft: ^1.4.1
   ts-jest: ^27.1.3
   tsup: ^6.5.0
   typescript: ^4.5.5
 
 dependencies:
   react-select: 5.7.0_crofjw4wgu3s56yfd4j5czcwki
-  spacetime: 7.1.4
-  timezone-soft: 1.3.1
+  spacetime: 7.4.1
+  timezone-soft: 1.4.1
 
 devDependencies:
   '@babel/core': 7.21.3
@@ -4819,8 +4819,8 @@ packages:
       whatwg-url: 7.1.0
     dev: true
 
-  /spacetime/7.1.4:
-    resolution: {integrity: sha512-ZzYuGjaMPE42p/fVU9Qcd+aMhgYzC83hgqMKyWlGILtponsLm5KJZgWzblLnOU8OblMQa3YXo/0IiZZ5JsTDfA==}
+  /spacetime/7.4.1:
+    resolution: {integrity: sha512-khQpvLNMhHFzfFJslMfunqqsjOxdmoDDYX5Wh4qYb8N6f8vBPI6HvbT7Wb2wcMa+oP1Xh1HpEcwfPFrj8UfvHQ==}
     dev: false
 
   /spawn-command/0.0.2-1:
@@ -5002,8 +5002,8 @@ packages:
     resolution: {integrity: sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==}
     dev: true
 
-  /timezone-soft/1.3.1:
-    resolution: {integrity: sha512-mphMogFJzQy6UIpl/UgKLSNbhmLtdgbz866TnqJ/CnWnc+7dsNyAe8nPwVdOW3Mf8nT0lA32MW/gYhAl4/RkVg==}
+  /timezone-soft/1.4.1:
+    resolution: {integrity: sha512-AnKhVnQmOjKHhdQXXe7cO7MyRGIHEGzedax4Y2N7nOr9dOYEFEBkWFJJwJTvPQvXsEtbWfa6xJj34iZKdC+W+g==}
     dev: false
 
   /tmpl/1.0.5:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,20 @@
 /// <reference types="react" />
-import allTimezones from './timezone-list.js';
-import type { Props, ITimezone, ITimezoneOption, ILabelStyle } from './types/timezone';
-export { allTimezones };
-export type { ITimezone, ITimezoneOption, Props, ILabelStyle };
-declare const TimezoneSelect: ({ value, onBlur, onChange, labelStyle, timezones, ...props }: Props) => JSX.Element;
-export default TimezoneSelect;
+import allTimezones from './timezone-list.js'
+import type {
+  Props,
+  ITimezone,
+  ITimezoneOption,
+  ILabelStyle,
+} from './types/timezone'
+export { allTimezones }
+export type { ITimezone, ITimezoneOption, Props, ILabelStyle }
+declare const TimezoneSelect: ({
+  value,
+  onBlur,
+  onChange,
+  labelStyle,
+  timezones,
+  maxAbbrLength,
+  ...props
+}: Props) => JSX.Element
+export default TimezoneSelect

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,10 +33,8 @@ const TimezoneSelect = ({
 
           let label = ''
           let abbr = now.isDST()
-            ? // @ts-expect-error
-              tzStrings[0].daylight.abbr
-            : // @ts-expect-error
-              tzStrings[0].standard.abbr
+            ? tzStrings[0].daylight.abbr
+            : tzStrings[0].standard.abbr
           let altName = now.isDST()
             ? tzStrings[0].daylight.name
             : tzStrings[0].standard.name

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,50 +26,54 @@ const TimezoneSelect = ({
   const getOptions = React.useMemo(() => {
     return Object.entries(timezones)
       .reduce<ITimezoneOption[]>((selectOptions, zone) => {
-        const now = spacetime.now(zone[0])
-        const tz = now.timezone()
-        const tzStrings = soft(zone[0])
+        try {
+          const now = spacetime.now(zone[0])
+          const tz = now.timezone()
+          const tzStrings = soft(zone[0])
 
-        let label = ''
-        let abbr = now.isDST()
-          ? // @ts-expect-error
-            tzStrings[0]?.daylight?.abbr ?? ''
-          : // @ts-expect-error
-            tzStrings[0]?.standard?.abbr ?? ''
-        let altName = now.isDST()
-          ? tzStrings[0]?.daylight?.name ?? ''
-          : tzStrings[0]?.standard?.name ?? ''
+          let label = ''
+          let abbr = now.isDST()
+            ? // @ts-expect-error
+              tzStrings[0].daylight.abbr
+            : // @ts-expect-error
+              tzStrings[0].standard.abbr
+          let altName = now.isDST()
+            ? tzStrings[0].daylight.name
+            : tzStrings[0].standard.name
 
-        const min = (tz?.current?.offset ?? 0) * 60
-        const hr =
-          `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
-        const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
+          const min = tz.current.offset * 60
+          const hr =
+            `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
+          const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
 
-        switch (labelStyle) {
-          case 'original':
-            label = prefix
-            break
-          case 'altName':
-            label = `${prefix} ${altName?.length ? `(${altName})` : ''}`
-            break
-          case 'abbrev':
-            label = `${prefix} ${
-              abbr?.length <= maxAbbrLength ? `(${abbr})` : ''
-            }`
-            break
-          default:
-            label = `${prefix}`
+          switch (labelStyle) {
+            case 'original':
+              label = prefix
+              break
+            case 'altName':
+              label = `${prefix} ${altName?.length ? `(${altName})` : ''}`
+              break
+            case 'abbrev':
+              label = `${prefix} ${
+                abbr?.length <= maxAbbrLength ? `(${abbr})` : ''
+              }`
+              break
+            default:
+              label = `${prefix}`
+          }
+
+          selectOptions.push({
+            value: tz.name,
+            label: label,
+            offset: tz.current.offset,
+            abbrev: abbr,
+            altName: altName,
+          })
+
+          return selectOptions
+        } catch {
+          return selectOptions
         }
-
-        selectOptions.push({
-          value: tz.name,
-          label: label,
-          offset: tz?.current?.offset ?? 0,
-          abbrev: abbr,
-          altName: altName,
-        })
-
-        return selectOptions
       }, [])
       .sort((a: ITimezoneOption, b: ITimezoneOption) => a.offset - b.offset)
   }, [labelStyle, timezones])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ const TimezoneSelect = ({
   onChange,
   labelStyle = 'original',
   timezones,
+  maxAbbrLength = 5,
   ...props
 }: Props) => {
   if (!timezones) timezones = allTimezones
@@ -32,14 +33,14 @@ const TimezoneSelect = ({
         let label = ''
         let abbr = now.isDST()
           ? // @ts-expect-error
-            tzStrings[0].daylight?.abbr
+            tzStrings[0]?.daylight?.abbr ?? ''
           : // @ts-expect-error
-            tzStrings[0].standard?.abbr
+            tzStrings[0]?.standard?.abbr ?? ''
         let altName = now.isDST()
-          ? tzStrings[0].daylight?.name
-          : tzStrings[0].standard?.name
+          ? tzStrings[0]?.daylight?.name ?? ''
+          : tzStrings[0]?.standard?.name ?? ''
 
-        const min = tz.current.offset * 60
+        const min = (tz?.current?.offset ?? 0) * 60
         const hr =
           `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
         const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
@@ -52,7 +53,9 @@ const TimezoneSelect = ({
             label = `${prefix} ${altName?.length ? `(${altName})` : ''}`
             break
           case 'abbrev':
-            label = `${prefix} ${abbr?.length < 5 ? `(${abbr})` : ''}`
+            label = `${prefix} ${
+              abbr?.length < maxAbbrLength ? `(${abbr})` : ''
+            }`
             break
           default:
             label = `${prefix}`
@@ -61,7 +64,7 @@ const TimezoneSelect = ({
         selectOptions.push({
           value: tz.name,
           label: label,
-          offset: tz.current.offset,
+          offset: tz?.current?.offset ?? 0,
           abbrev: abbr,
           altName: altName,
         })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,9 +52,7 @@ const TimezoneSelect = ({
               label = `${prefix} ${altName?.length ? `(${altName})` : ''}`
               break
             case 'abbrev':
-              label = `${prefix} ${
-                abbr?.length <= maxAbbrLength ? `(${abbr})` : ''
-              }`
+              label = `${prefix} (${abbr.substring(0, maxAbbrLength)})`
               break
             default:
               label = `${prefix}`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ const TimezoneSelect = ({
   onChange,
   labelStyle = 'original',
   timezones,
-  maxAbbrLength = 5,
+  maxAbbrLength = 4,
   ...props
 }: Props) => {
   if (!timezones) timezones = allTimezones
@@ -54,7 +54,7 @@ const TimezoneSelect = ({
             break
           case 'abbrev':
             label = `${prefix} ${
-              abbr?.length < maxAbbrLength ? `(${abbr})` : ''
+              abbr?.length <= maxAbbrLength ? `(${abbr})` : ''
             }`
             break
           default:

--- a/src/tests/TimezoneSelect.spec.tsx
+++ b/src/tests/TimezoneSelect.spec.tsx
@@ -136,7 +136,7 @@ test('select drop-downs must use the fireEvent.change', () => {
     ...container.querySelectorAll('div[id^="react-select"]'),
   ].find(n => n.textContent === '(GMT-10:00) Hawaii')
 
-  fireEvent.click(selectOption)
+  selectOption && fireEvent.click(selectOption)
 
   expect(onChangeSpy).toHaveBeenCalledTimes(1)
   expect(onChangeSpy).toHaveBeenCalledWith({
@@ -146,4 +146,40 @@ test('select drop-downs must use the fireEvent.change', () => {
     offset: -10,
     abbrev: 'HAST',
   })
+})
+
+test('load and displays for timezone has empty response from spacetime ', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Antigua'}
+      onChange={e => e}
+      timezones={{ ...allTimezones, 'America/Antigua': 'Antigua' }}
+    />
+  )
+
+  expect(getByText(/Antigua/)).toBeInTheDocument()
+})
+
+test('load and show abbrevations according to maxAbbrLength(5)', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Chihuahua'}
+      onChange={e => e}
+      labelStyle="abbrev"
+      maxAbbrLength={5}
+    />
+  )
+
+  expect(getByText(/\(HNPMX\)$/)).toBeInTheDocument()
+})
+
+test('load and show abbrevations according to default maxAbbrLength(4)', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Chihuahua'}
+      onChange={e => e}
+      labelStyle="abbrev"
+    />
+  )
+  expect(getByText(/Chihuahua/)).not.toContain('HNPMX')
 })

--- a/src/tests/TimezoneSelect.spec.tsx
+++ b/src/tests/TimezoneSelect.spec.tsx
@@ -148,6 +148,20 @@ test('select drop-downs must use the fireEvent.change', () => {
   })
 })
 
+test('loads and does not throw on missing timezone', async () => {
+  expect(() =>
+    render(
+      <TimezoneSelect
+        value={'Europe/Berlin'}
+        timezones={{
+          'America/SmallTownMissing': 'Missing',
+        }}
+        onChange={e => e}
+      />
+    )
+  ).not.toThrowError(/Please enter an IANA timezone id/i)
+})
+
 test('load and displays for timezone has empty response from spacetime ', async () => {
   const { getByText } = render(
     <TimezoneSelect

--- a/src/types/timezone.d.ts
+++ b/src/types/timezone.d.ts
@@ -17,4 +17,5 @@ export interface Props
   labelStyle?: ILabelStyle
   onChange?: (timezone: ITimezoneOption) => void
   timezones?: ICustomTimezone
+  maxAbbrLength?: number
 }

--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -22,4 +22,5 @@ export interface Props
   labelStyle?: ILabelStyle
   onChange?: (timezone: ITimezoneOption) => void
   timezones?: ICustomTimezone
+  maxAbbrLength?: number
 }


### PR DESCRIPTION
### Description

There are some timezones that timezone-soft library doesn't return an object of definitions for them. So in that case the current code is facing accessing a property of an undefined object. More details and screenshots of an error can be found in the linked issue notification.

As a solution, I have updated library versions and also added an optional chaining control while accessing a property of tzString objects.

### Linked Issues

https://github.com/ndom91/react-timezone-select/issues/76

### Additional context

- Abbreviation visibility was hard coded to a maximum of 5 characters. I made it configurable by adding a prop. 