### PR TITLE
Control Added to Include Timezones that has issue with altname and ab…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,12 +29,16 @@ const TimezoneSelect = ({
             const tzStrings = soft(zone[0])
 
             let label = ''
-            let abbr = now.isDST()
-              ? tzStrings[0].daylight.abbr
-              : tzStrings[0].standard.abbr
-            let altName = now.isDST()
-              ? tzStrings[0].daylight.name
-              : tzStrings[0].standard.name
+
+            const standardAbbr = tzStrings?.[0]?.standard?.abbr ?? ''
+            const dstAbbr = tzStrings?.[0]?.daylight?.abbr ?? standardAbbr
+
+            let abbr = now.isDST() ? dstAbbr : standardAbbr
+
+            const standardAltName = tzStrings?.[0]?.standard?.name ?? ''
+            const dstAltName = tzStrings?.[0]?.daylight?.name ?? standardAltName
+
+            let altName = now.isDST() ? dstAltName : standardAltName
 
             const min = tz.current.offset * 60
             const hr =
@@ -47,7 +51,7 @@ const TimezoneSelect = ({
                 label = prefix
                 break
               case 'altName':
-                label = `${prefix} ${altName?.length ? `(${altName})` : ''}`
+                label = `${prefix} ${altName ? `(${altName})` : ''}`
                 break
               case 'abbrev':
                 label = `${prefix} (${abbr.substring(0, maxAbbrLength)})`

--- a/src/tests/TimezoneSelect.spec.tsx
+++ b/src/tests/TimezoneSelect.spec.tsx
@@ -185,3 +185,18 @@ test('load and show abbrevations according to default maxAbbrLength(4)', async (
   )
   expect(getByText(/Chihuahua/)).not.toContain('H(N|E)PMX')
 })
+
+test('load and does not omit timezone that isDST is true and doesn not have daylight definitions', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'Asia/Tehran'}
+      timezones={{
+        ...allTimezones,
+        'Asia/Tehran': 'Tehran',
+      }}
+      onChange={e => e}
+    />
+  )
+
+  expect(getByText(/Tehran/)).toBeInTheDocument()
+})


### PR DESCRIPTION
### Description
When there are issues with abbreviations or alt names the timezones get omitted from the list. I add control to keep them in the options list with a fallback to standard values.

### Linked Issues

https://github.com/ndom91/react-timezone-select/issues/95

### Additional context
