### PR TITLE
Display value utc

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The above example will generate two additional choices in the select options, on
 - `onBlur` - `() => void`
 - `onChange` - `(timezone) => void`
 - `labelStyle` - `'original' | 'altName' | 'abbrev'`
+- `displayValue` - `'GMT' | 'UTC'`
 - `timezones` - `Record<string,string>`
 ```
 timezones={{

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { TimezoneSelectOptions } from './types/timezone'
 export function useTimezoneSelect({
   timezones = allTimezones,
   labelStyle = 'original',
+  displayValue = 'GMT',
   maxAbbrLength = 4,
 }: TimezoneSelectOptions): {
   parseTimezone: (zone: ITimezone) => ITimezoneOption
@@ -41,9 +42,10 @@ export function useTimezoneSelect({
 
           const min = tz.current.offset * 60
           const hr =
-            `${(min / 60) ^ 0}:` +
-            (min % 60 === 0 ? '00' : Math.abs(min % 60))
-          const prefix = `(GMT${hr.includes('-') ? hr : `+${hr}`}) ${zone[1]}`
+            `${(min / 60) ^ 0}:` + (min % 60 === 0 ? '00' : Math.abs(min % 60))
+          const prefix = `(${displayValue}${
+            hr.includes('-') ? hr : `+${hr}`
+          }) ${zone[1]}`
 
           switch (labelStyle) {
             case 'original':
@@ -148,6 +150,7 @@ const TimezoneSelect = ({
   onBlur,
   onChange,
   labelStyle,
+  displayValue,
   maxAbbrLength,
   timezones,
   ...props
@@ -155,6 +158,7 @@ const TimezoneSelect = ({
   const { options, parseTimezone } = useTimezoneSelect({
     timezones,
     labelStyle,
+    displayValue,
     maxAbbrLength,
   })
 
@@ -174,4 +178,10 @@ const TimezoneSelect = ({
 }
 
 export { TimezoneSelect as default, allTimezones }
-export type { ITimezone, ITimezoneOption, Props, ILabelStyle, TimezoneSelectOptions }
+export type {
+  ITimezone,
+  ITimezoneOption,
+  Props,
+  ILabelStyle,
+  TimezoneSelectOptions,
+}

--- a/src/tests/TimezoneSelect.spec.tsx
+++ b/src/tests/TimezoneSelect.spec.tsx
@@ -200,3 +200,15 @@ test('load and does not omit timezone that isDST is true and doesn not have dayl
 
   expect(getByText(/Tehran/)).toBeInTheDocument()
 })
+
+test('load and displays UTC', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Juneau'}
+      displayValue="UTC"
+      onChange={e => e}
+    />
+  )
+
+  expect(getByText(/\(UTC-[8-9]:00\) Alaska$/)).toBeInTheDocument()
+})

--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -6,6 +6,8 @@ export type ICustomTimezone = {
 
 export type ILabelStyle = 'original' | 'altName' | 'abbrev'
 
+export type IDisplayValue = 'GMT' | 'UTC'
+
 export type ITimezoneOption = {
   value: string
   label: string
@@ -18,6 +20,7 @@ export type ITimezone = ITimezoneOption | string
 
 export type TimezoneSelectOptions = {
   labelStyle?: ILabelStyle
+  displayValue?: IDisplayValue
   timezones?: ICustomTimezone
   maxAbbrLength?: number
 }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds a `displayValue` prop that allows to prepend UTC instead of GMT.

### Linked Issues

fix #65 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
