### PR TITLE
Add ability to set datetime for calculating timezone values

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The above example will generate two additional choices in the select options, on
 - `labelStyle` - `'original' | 'altName' | 'abbrev' | 'offsetHidden'`
 - `displayValue` - `'GMT' | 'UTC'`
 - `timezones` - `Record<string,string>`
+- `currentDatetime` - `Date | string` - Set datetime used to calculate timezone values (alternative to current datetime) 
 ```
 timezones={{
   ...allTimezones,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export function useTimezoneSelect({
   timezones = allTimezones,
   labelStyle = 'original',
   displayValue = 'GMT',
+  currentDatetime,
 }: TimezoneSelectOptions): {
   parseTimezone: (zone: ITimezone) => ITimezoneOption
   options: ITimezoneOption[]
@@ -23,7 +24,9 @@ export function useTimezoneSelect({
     return Object.entries(timezones)
       .map((zone) => {
         try {
-          const now = spacetime.now(zone[0])
+          const now = (
+            currentDatetime ? spacetime(currentDatetime) : spacetime.now()
+          ).goto(zone[0])
           const isDstString = now.isDST() ? 'daylight' : 'standard'
           const tz = now.timezone()
           const tzStrings = soft(zone[0])
@@ -76,9 +79,13 @@ export function useTimezoneSelect({
   const findFuzzyTz = (zone: string): ITimezoneOption => {
     let currentTime: Spacetime
     try {
-      currentTime = spacetime.now(zone)
+      currentTime = (
+        currentDatetime ? spacetime(currentDatetime) : spacetime.now()
+      ).goto(zone)
     } catch (err) {
-      currentTime = spacetime.now('GMT')
+      currentTime = (
+        currentDatetime ? spacetime(currentDatetime) : spacetime.now()
+      ).goto('GMT')
     }
 
     return options
@@ -149,12 +156,14 @@ const TimezoneSelect = ({
   labelStyle,
   displayValue,
   timezones,
+  currentDatetime,
   ...props
 }: Props) => {
   const { options, parseTimezone } = useTimezoneSelect({
     timezones,
     labelStyle,
     displayValue,
+    currentDatetime,
   })
 
   const handleChange = (tz: ITimezoneOption) => {

--- a/src/tests/TimezoneSelect.spec.tsx
+++ b/src/tests/TimezoneSelect.spec.tsx
@@ -173,3 +173,27 @@ test('load and displays UTC', async () => {
 
   expect(getByText(/\(UTC-[8-9]:00\) Alaska$/)).toBeInTheDocument()
 })
+
+test('can set current time (DST)', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Detroit'}
+      currentDatetime="2017-07-08"
+      onChange={(e) => e}
+    />,
+  )
+
+  expect(getByText(/GMT-4/)).toBeInTheDocument()
+})
+
+test('can set current time (standard)', async () => {
+  const { getByText } = render(
+    <TimezoneSelect
+      value={'America/Detroit'}
+      currentDatetime="2017-01-27"
+      onChange={(e) => e}
+    />,
+  )
+
+  expect(getByText(/GMT-5/)).toBeInTheDocument()
+})

--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -22,6 +22,7 @@ export type TimezoneSelectOptions = {
   labelStyle?: ILabelStyle
   displayValue?: IDisplayValue
   timezones?: ICustomTimezone
+  currentDatetime?: Date | string
 }
 
 export type Props = Omit<ReactSelectProps<ITimezone, false>, 'onChange'> &


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add an optional prop used to set the current date to determine DST offset values to available timezones.

- Add a new optional prop called `currentDatetime` to `useTimezoneSelect` and `Timezone` components for use to calculate timezone values
  - new prop defined to accept `Date | string` types as supported by spacetime
- Add tests that set DST and standard timezones
- Update prop section in README


### Linked Issues

Inspired by https://github.com/ndom91/react-timezone-select/pull/63

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
