### PR TITLE
fix: incorrect type for onChange handler argument

### DIFF
--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -1,12 +1,12 @@
-import type { Props as ReactSelectProps } from 'react-select'
+import type { Props as ReactSelectProps } from "react-select"
 
 export type ICustomTimezone = {
   [key: string]: string
 }
 
-export type ILabelStyle = 'original' | 'altName' | 'abbrev' | 'offsetHidden'
+export type ILabelStyle = "original" | "altName" | "abbrev" | "offsetHidden"
 
-export type IDisplayValue = 'GMT' | 'UTC'
+export type IDisplayValue = "GMT" | "UTC"
 
 export type ITimezoneOption = {
   value: string
@@ -25,8 +25,8 @@ export type TimezoneSelectOptions = {
   currentDatetime?: Date | string
 }
 
-export type Props = Omit<ReactSelectProps<ITimezone, false>, 'onChange'> &
+export type Props = Omit<ReactSelectProps<ITimezone, false>, "onChange"> &
   TimezoneSelectOptions & {
     value: ITimezone
-    onChange?: (timezone: ITimezone) => void
+    onChange?: (timezone: ITimezoneOption) => void
   }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Fix `onChange` argument type from `ITimezone` (which was a union between the full `ITimezoneOption` object and `string`) to `ITimezoneOption` only.

Since the `value` can be both a `string` (i.e. `Europe/Berlin`) or the full `ITimezoneOption` object, that's okay, but after going through the component and coming _out_ of the `onChange` function, so to speak, it'll always be the `ITimezoneOption` object. Never a `string` as an argument in `onChange`.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
