### PR TITLE
fix: main `useMemo`, add dependency on `currentDatetime`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,7 +63,7 @@ export function useTimezoneSelect({
       })
       .filter(Boolean)
       .sort((a: ITimezoneOption, b: ITimezoneOption) => a.offset - b.offset)
-  }, [labelStyle, timezones])
+  }, [labelStyle, timezones, currentDatetime])
 
   const findFuzzyTz = (zone: string): ITimezoneOption => {
     let currentTime: Spacetime


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

My use case, which feels pretty common, has me wanting the timezone options to update when the `currentDatetime` changes.  So if we include a date picker in our app and the user chooses a date in which the timezones switch from standard to daylight, the options in the select update automatically.

### Linked Issues

More detail, and an updated example can be found in this [forked branch](https://github.com/weissleb/react-timezone-select/tree/add-date-picker-to-example).  I also opened an [enhancement issue](https://github.com/ndom91/react-timezone-select/issues/123).

### Additional context

If there's a preferred way of accomplishing my goal without this change, I'm all ears!

Fixes: #123