### PR TITLE
fix: ReactSelectProps type usage

### DIFF
--- a/src/types/timezone.ts
+++ b/src/types/timezone.ts
@@ -25,7 +25,7 @@ export type TimezoneSelectOptions = {
   currentDatetime?: Date | string
 }
 
-export type Props = Omit<ReactSelectProps<ITimezone, false>, "onChange"> &
+export type Props = Omit<ReactSelectProps<ITimezone>, "onChange"> &
   TimezoneSelectOptions & {
     value: ITimezone
     onChange?: (timezone: ITimezoneOption) => void


### PR DESCRIPTION
### Description
Current usage of the `ReactSelectProps` type leads to an error when switching from 1.x.x version to 3.x.x.
Example:
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/9680978a-8d08-4f16-ac02-785e3d9202c4">
This issue was caused by `false` being passed to the `ReactSelectProps` type, after removing `false` the issue on the screenshot disappeared. Alternatively `false` could be replaced with `boolean` but it does not make any sense because `ReactSelectProps` by default uses it as a boolean, ref.: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/useStateManager.ts#L35C10-L35C32

### Linked Issues

### Additional context
In the [current implementation](https://github.com/ndom91/react-timezone-select/blob/main/src/types/timezone.ts#L28) there is a `false` value for the `isMulti` generic variable. So, setting `isMulti` to `true` is impossible.

