### PR TITLE
Added "require" to exports for react-native-web imports to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

Lovely package. I had to add this simple one-liner to it in order to use it from a React-Native-Web application I'm working on. I probably would have gotten by with just using `npx patch-package react-timezone-select` but `pack-package` is ignoring my change to `package.json`

### Linked Issues

Didn't create one, just went and requested this change.

### Additional context

If you need an example react-native-web integration, let me know.
