### PR TITLE
fix: move react-select from peer-dep to dev-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "peerDependencies": {
     "react": "^16 || ^17.0.1 || ^18 || ^19.0.0-0",
-    "react-dom": "^16 || ^17.0.1 || ^18 || ^19.0.0-0",
-    "react-select": "^5.8.0"
+    "react-dom": "^16 || ^17.0.1 || ^18 || ^19.0.0-0"
   },
   "dependencies": {
     "spacetime": "^7.6.0",
@@ -75,6 +74,7 @@
     "prettier": "^3.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-select": "^5.8.0",
     "simple-git-hooks": "^2.11.1",
     "ts-jest": "^29.2.3",
     "tsup": "^8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      react-select:
-        specifier: ^5.8.0
-        version: 5.8.3(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       spacetime:
         specifier: ^7.6.0
         version: 7.6.2
@@ -81,6 +78,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-select:
+        specifier: ^5.8.0
+        version: 5.8.3(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1


### PR DESCRIPTION
### Description

The documentation indicates that `react-select` is optional if end users are only interested in the `useTimezoneSelect` hook. However, by making `react-select` a peer dependency, it will be installed anyways.

This PR moves `react-select` from peer dependencies to dev dependencies. By doing this, we can be sure the package will always be available on install for dev work, but will not install itself without the end user wanting it.

### Linked Issues

fix: #145
